### PR TITLE
Bump addon-wait to 0.2.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ unset GIT_DIR
 BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 
-PACKAGE_URL=https://github.com/heroku/addon-wait/releases/download/0.1.0/addon-wait-linux-64.gz
+PACKAGE_URL=https://github.com/heroku/addon-wait/releases/download/0.2.0/addon-wait-linux-64.gz
 TARGET_FILE=$BUILD_DIR/bin/addon-wait
 
 echo "-----> Downloading addon-wait into app/bin"


### PR DESCRIPTION
See https://github.com/heroku/addon-wait/pull/1.