### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DEPRECATED
+This buildpack is no longer required and is unsupported as its functionality has been built directly into the Heroku [app-setups](https://devcenter.heroku.com/articles/platform-api-reference#app-setup) API.
+
 # Heroku buildpack: Addon Wait
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that installs a small tool for waiting on Postgres and Redis addons to become available.
@@ -13,4 +16,3 @@ $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-addon-wait.gi
 ```
 
 Then you can add `bin/addon-wait` as post deploy script to your `app.json`, see [here for details](https://devcenter.heroku.com/articles/setting-up-apps-using-the-heroku-platform-api#post-deployment-scripts).
-

--- a/bin/compile
+++ b/bin/compile
@@ -19,7 +19,7 @@ TARGET_FILE=$BUILD_DIR/bin/addon-wait
 echo "!----> BUILDPACK DEPRECATED"
 echo "       This buildpack is no longer required and is unsupported as its"
 echo "       functionality has been built directly into the Heroku app-setups"
-echo         "API"
+echo         "API."
 echo ""
 echo "-----> Downloading addon-wait into app/bin"
 mkdir -p $BUILD_DIR/bin

--- a/bin/compile
+++ b/bin/compile
@@ -16,6 +16,11 @@ BUILDPACK_DIR="$(dirname $(dirname $0))"
 PACKAGE_URL=https://github.com/heroku/addon-wait/releases/download/0.2.0/addon-wait-linux-64.gz
 TARGET_FILE=$BUILD_DIR/bin/addon-wait
 
+echo "!----> BUILDPACK DEPRECATED"
+echo "       This buildpack is no longer required and is unsupported as its"
+echo "       functionality has been built directly into the Heroku app-setups"
+echo         "API"
+echo ""
 echo "-----> Downloading addon-wait into app/bin"
 mkdir -p $BUILD_DIR/bin
 curl $PACKAGE_URL -s -L -o - | gunzip > $TARGET_FILE


### PR DESCRIPTION
Heroku postgres and Redis support async provisioning and so does the app setups API so this buildpack is no longer needed.